### PR TITLE
Adds Unit Death

### DIFF
--- a/src/controller/combat.ts
+++ b/src/controller/combat.ts
@@ -57,7 +57,6 @@ const controller_initBattle = () => {
   G_model_setCurrentBattle(battle);
 
   G_view_drawBattle(battle);
-  // G_view_drawMenu();
   const options = ['Strike', 'Charge', 'Defend', 'Use', 'Heal', 'Flee'];
   G_view_drawMenu(options, 'white', 195, 380, 100, 120, 18);
   G_model_setBattleInputEnabled(true);

--- a/src/controller/combat.ts
+++ b/src/controller/combat.ts
@@ -25,10 +25,29 @@ G_ACTION_STRIKE
 
 const G_controller_initBattle = () => {
   const jimothy = G_model_createUnit('Jimothy', 5, 5, 5, 5, 5);
-  const karst = G_model_createUnit('Karst', 7, 2, 4, 3, 1);
+  const seph = G_model_createUnit('Seph', 7, 2, 4, 3, 1);
+  const kana = G_model_createUnit('Kana', 5, 8, 3, 2, 7);
+  const widdly2Diddly = G_model_createUnit('widdly2Diddly', 7, 7, 7, 7, 7);
 
-  const battle = G_model_createBattle([jimothy], [karst]);
-  const firstRound = G_model_createRound([jimothy, karst]);
+  const karst = G_model_createUnit('Karst', 6, 4, 4, 3, 5);
+  const urien = G_model_createUnit('Urien', 9, 5, 4, 3, 2);
+  const shreth = G_model_createUnit('Shreth', 8, 8, 6, 3, 2);
+  const pDiddy = G_model_createUnit('P Diddy', 5, 5, 5, 5, 5);
+
+  const battle = G_model_createBattle(
+    [jimothy, seph, kana, widdly2Diddly],
+    [karst, urien, shreth, pDiddy]
+  );
+  const firstRound = G_model_createRound([
+    jimothy,
+    karst,
+    seph,
+    urien,
+    kana,
+    shreth,
+    widdly2Diddly,
+    pDiddy,
+  ]);
 
   G_model_battleAddRound(battle, firstRound);
   G_model_setCurrentBattle(battle);

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -23,7 +23,7 @@ G_controller_battleActionHeal
 
 window.addEventListener('keydown', ev => {
   G_model_setKeyDown(ev.key);
-  console.log('KEY', ev.key);
+  // console.log('KEY', ev.key);
 
   if (ev.key === 'q') {
     (window as any).running = false;

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -10,6 +10,9 @@ G_BATTLE_CURRENT_BATTLE
 G_controller_battleSimulateNextRound
 G_model_getCurrentBattle
 G_model_getBattleInputEnabled
+G_model_getCursorIndex
+G_model_setCursorIndex
+G_view_drawMenu
 */
 
 /* Event Flags */
@@ -25,6 +28,19 @@ window.addEventListener('keydown', ev => {
     if (ev.key === ' ' || ev.key === 'b') {
       // console.log('keypress!!!', ev);
       G_controller_battleSimulateNextRound(G_model_getCurrentBattle());
+    }
+
+    if (ev.key === 'ArrowDown') {
+      const index = G_model_getCursorIndex();
+      G_model_setCursorIndex((index + 1) % 6);
+      G_view_drawMenu(['Strike', 'Charge', 'Defend', 'Use', 'Heal', 'Flee']);
+    }
+
+    if (ev.key === 'ArrowUp') {
+      const index = G_model_getCursorIndex();
+      const newIndex = index - 1 < 0 ? 5 : index - 1;
+      G_model_setCursorIndex(newIndex);
+      G_view_drawMenu(['Strike', 'Charge', 'Defend', 'Use', 'Heal', 'Flee']);
     }
   }
 });

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -20,13 +20,14 @@ G_view_drawMenu
 window.addEventListener('keydown', ev => {
   G_model_setKeyDown(ev.key);
 
+  console.log('keypress!!!', ev);
+
   if (ev.key === 'q') {
     (window as any).running = false;
   }
 
   if (G_model_getBattleInputEnabled()) {
     if (ev.key === ' ' || ev.key === 'b') {
-      // console.log('keypress!!!', ev);
       G_controller_battleSimulateNextRound(G_model_getCurrentBattle());
     }
 
@@ -42,6 +43,8 @@ window.addEventListener('keydown', ev => {
       G_model_setCursorIndex(newIndex);
       G_view_drawMenu(['Strike', 'Charge', 'Defend', 'Use', 'Heal', 'Flee']);
     }
+
+    // if (ev.key === 'Enter') {}
   }
 });
 

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -33,7 +33,7 @@ window.addEventListener('keydown', ev => {
     const key = ev.key;
 
     try {
-      const menu = battle.actionMenu;
+      const menu = battle.actionMenuStack[0];
       if (key === 'ArrowDown') {
         G_model_menuSetNextCursorIndex(menu, 1);
       } else if (key === 'ArrowUp') {

--- a/src/controller/events.ts
+++ b/src/controller/events.ts
@@ -13,6 +13,7 @@ G_model_roundGetActingUnit
 G_model_battleGetCurrentRound
 G_model_menuSetNextCursorIndex
 G_model_menuSelectCurrentItem
+G_model_menuSelectNothing
 G_view_drawMenu
 G_view_drawBattle
 G_controller_battleSimulateNextRound
@@ -40,6 +41,10 @@ window.addEventListener('keydown', ev => {
         G_model_menuSetNextCursorIndex(menu, -1);
       } else if (key === 'Enter') {
         G_model_menuSelectCurrentItem(menu);
+      } else if (key === 'Escape') {
+        if (battle.actionMenuStack.length > 1) {
+          G_model_menuSelectNothing(menu);
+        }
       }
     } finally {
       // using a `finally` here because we want to call `drawBattle` after any case in the previous block

--- a/src/model/actor.ts
+++ b/src/model/actor.ts
@@ -65,6 +65,10 @@ const G_model_actorSetPosition = (actor: Actor, x: number, y: number) => {
   actor.y = y;
 };
 
+const G_model_actorGetPosition = (actor: Actor): [number, number] => {
+  return [actor.x, actor.y];
+};
+
 const G_model_actorSetVelocity = (actor: Actor, vx: number, vy: number) => {
   actor.vx = vx;
   actor.vy = vy;

--- a/src/model/actor.ts
+++ b/src/model/actor.ts
@@ -4,13 +4,18 @@ An Actor is an entity on the screen which is affected by gravity.
 /*
 global
 G_SPRITE_MOD_FLIPPED
+G_SPRITE_MOD_FLROT90
+G_SPRITE_MOD_ROT90
+G_SPRITE_MOD_ROT270
 G_model_getElapsedMs
 G_utils_floorNearestMultiple
 */
 
-type Facing = 0 | 1;
+type Facing = 0 | 1 | 2 | 3;
 const G_FACING_LEFT: Facing = 0;
 const G_FACING_RIGHT: Facing = 1;
+const G_FACING_UP_RIGHT: Facing = 2;
+const G_FACING_UP_LEFT: Facing = 3;
 
 type AnimState = 0 | 1 | 2;
 const G_ANIM_DEFAULT: AnimState = 0;
@@ -81,11 +86,22 @@ const G_model_actorGetCurrentSprite = (actor: Actor): string => {
     anim = (anim -
       Math.floor((G_model_getElapsedMs() % 200) / 100)) as AnimState;
   }
-  return (
-    sprite +
-    `_${spriteIndex + anim}` +
-    (facing === G_FACING_LEFT ? G_SPRITE_MOD_FLIPPED : '')
-  );
+  let mod = '';
+  switch (facing) {
+    case 0:
+      mod = G_SPRITE_MOD_FLIPPED;
+      break;
+    // case 1 is no modification
+    case 2: // up
+      mod = G_SPRITE_MOD_ROT270;
+      break;
+    case 3:
+      mod = G_SPRITE_MOD_FLROT90;
+      break;
+    default:
+      break;
+  }
+  return sprite + `_${spriteIndex + anim + mod}`;
 };
 
 const G_model_actorSetAnimState = (actor: Actor, anim: AnimState) => {

--- a/src/model/battle.ts
+++ b/src/model/battle.ts
@@ -1,6 +1,8 @@
 /*
 global
 G_controller_roundApplyAction
+G_controller_unitLives
+G_controller_killUnit
 G_model_createVerticalMenu
 G_model_getScreenSize
 G_model_getSprite
@@ -30,15 +32,15 @@ interface Battle {
 }
 
 type RoundAction = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-const G_ACTION_STRIKE: RoundAction = 0;
+const G_ACTION_STRIKE: RoundAction = 0; // requires target
 const G_ACTION_CHARGE: RoundAction = 1;
-const G_ACTION_INTERRUPT: RoundAction = 2;
+const G_ACTION_INTERRUPT: RoundAction = 2; // requires target
 const G_ACTION_DEFEND: RoundAction = 3;
 const G_ACTION_HEAL: RoundAction = 4;
-const G_ACTION_USE: RoundAction = 5;
+const G_ACTION_USE: RoundAction = 5; // may require target
 const G_ACTION_FLEE: RoundAction = 6;
 const G_BATTLE_MENU_LABELS = [
-  // make sure these indexes match above
+  // make sure these indices match above
   'Strike',
   'Charge',
   'Interrupt',
@@ -133,17 +135,18 @@ const handleActionMenuSelected = async (i: RoundAction) => {
   const battle = G_model_getCurrentBattle();
   const round = G_model_battleGetCurrentRound(battle);
 
-  // here we could 'await' target selection instead of randomly picking one
-  const target: Unit | null = await selectTarget(battle);
-
-  // handles the case where ESC (or back or something) is pressed while targeting
-  if (!target) {
-    return;
-  }
-
   switch (i) {
     case G_ACTION_STRIKE:
+      // here we could 'await' target selection instead of randomly picking one
+      const target: Unit | null = await selectTarget(battle);
+      // handles the case where ESC (or back or something) is pressed while targeting
+      if (!target) {
+        return;
+      }
       G_controller_roundApplyAction(G_ACTION_STRIKE, round, target);
+      break;
+    case G_ACTION_HEAL:
+      G_controller_roundApplyAction(G_ACTION_HEAL, round, null);
       break;
     default:
       console.error('Action', i, 'Is not implemented yet.');

--- a/src/model/battle.ts
+++ b/src/model/battle.ts
@@ -6,8 +6,6 @@ G_controller_killUnit
 G_model_createVerticalMenu
 G_model_getScreenSize
 G_model_getSprite
-G_model_getSpriteSize
-G_model_getScreenSize
 G_view_drawBattle
 G_view_drawMenu
 G_utils_areAllUnitsDead
@@ -29,6 +27,7 @@ interface Battle {
   rounds: Round[];
   roundIndex: 0;
   actionMenuStack: Menu[];
+  text: string;
 }
 
 type RoundAction = 0 | 1 | 2 | 3 | 4 | 5 | 6;
@@ -87,7 +86,14 @@ const G_model_createBattle = (allies: Unit[], enemies: Unit[]): Battle => {
       lineHeight
     ),
   ];
-  return { allies, enemies, rounds: [], roundIndex: 0, actionMenuStack };
+  return {
+    allies,
+    enemies,
+    rounds: [],
+    roundIndex: 0,
+    actionMenuStack,
+    text: '',
+  };
 };
 
 const G_model_battleGetScreenPosition = (
@@ -214,4 +220,8 @@ const G_model_battleIsComplete = (battle: Battle) => {
     G_utils_areAllUnitsDead(battle.enemies) ||
     G_utils_areAllUnitsDead(battle.allies)
   );
+};
+
+const G_model_actionToString = (i: number): string => {
+  return G_BATTLE_MENU_LABELS[i];
 };

--- a/src/model/battle.ts
+++ b/src/model/battle.ts
@@ -71,6 +71,13 @@ const G_utils_getSpriteHeight = (unit: Unit): number => {
   return G_model_getSprite(`${sprite}_${spriteIndex}`)[4];
 };
 
+const G_utils_getSpriteWidth = (unit: Unit): number => {
+  // console.log('Unit:', unit);
+  const { sprite, spriteIndex } = unit.actor;
+  // console.log('Sprite:', `${sprite}_${spriteIndex}`);
+  return G_model_getSprite(`${sprite}_${spriteIndex}`)[3];
+};
+
 let G_BATTLE_TARGET_INDEX = -1;
 
 const G_controller_setBattleTargetIndex = (i: number) => {
@@ -85,17 +92,25 @@ const handleTargetMenuInput = (i: number) => {
   G_controller_setBattleTargetIndex(i);
 };
 
+// These will be used to phase out positioning constants
+const G_SCALE = 2;
+const ALLY_X = 80;
+const ENEMY_X = 80;
+const Y_OFFSET = 27;
+
 const selectTarget = async (actingUnit: Unit) => {
   const battle = G_model_getCurrentBattle();
-  const x = G_utils_isAlly(battle, actingUnit) ? 200 : 40;
+  const x = G_utils_isAlly(battle, actingUnit) ? 200 * G_SCALE : 80 * G_SCALE;
+  const h = G_utils_getSpriteHeight(actingUnit);
+  console.log('x:', x);
   const targetMenu = G_model_createVerticalMenu(
     x,
-    70,
+    70 * G_SCALE - h / 2,
     0,
     Array(4).fill(''),
     handleTargetMenuInput,
-    true,
-    G_utils_getSpriteHeight(actingUnit)
+    false,
+    Y_OFFSET + h * G_SCALE
   );
   battle.actionMenuStack.push(targetMenu);
   return new Promise(resolve => {

--- a/src/model/menu.ts
+++ b/src/model/menu.ts
@@ -60,3 +60,7 @@ const G_model_menuSetNextCursorIndex = (menu: Menu, diff: MenuIncrement) => {
 const G_model_menuSelectCurrentItem = (menu: Menu) => {
   menu.cb(menu.i);
 };
+
+const G_model_menuSelectNothing = (menu: Menu) => {
+  menu.cb(-1);
+};

--- a/src/model/sprite.ts
+++ b/src/model/sprite.ts
@@ -5,8 +5,11 @@ within the parent image (the four numbers: x, y, width, height).
 */
 /*
 global
-G_view_drawSprite
+G_controller_unitLives
 G_model_createCanvas
+G_model_getCurrentBattle
+G_utils_isAlly
+G_view_drawSprite
 */
 
 type Sprite = [
@@ -31,12 +34,13 @@ const createSprite = (
 type SpriteCollection = { [key: string]: Sprite };
 
 // This type represents the postfix one can add to a sprite
-type SpriteModification = '' | '_r1' | '_r2' | '_r3' | '_f';
+type SpriteModification = '' | '_r1' | '_r2' | '_r3' | '_f' | '_fr1';
 const G_SPRITE_MOD_NORMAL: SpriteModification = '';
 const G_SPRITE_MOD_FLIPPED: SpriteModification = '_f';
 const G_SPRITE_MOD_ROT90: SpriteModification = '_r1';
 const G_SPRITE_MOD_ROT180: SpriteModification = '_r2';
 const G_SPRITE_MOD_ROT270: SpriteModification = '_r3';
+const G_SPRITE_MOD_FLROT90: SpriteModification = '_fr1';
 
 let model_sprites: SpriteCollection | null = null;
 
@@ -142,6 +146,15 @@ const loadSpritesFromImage = (
       addSprite(
         `${baseSpriteName}${G_SPRITE_MOD_FLIPPED}`,
         createFlippedImg(spriteToCanvas(sprite)),
+        0,
+        0,
+        spriteWidth,
+        spriteHeight
+      );
+
+      addSprite(
+        `${baseSpriteName}${G_SPRITE_MOD_FLROT90}`,
+        createRotatedImg(createFlippedImg(spriteToCanvas(sprite))),
         0,
         0,
         spriteWidth,

--- a/src/model/sprite.ts
+++ b/src/model/sprite.ts
@@ -203,3 +203,5 @@ const G_model_loadImagesAndSprites = async () => {
 // get a Sprite given a sprite name
 const G_model_getSprite = (spriteName: string): Sprite =>
   (model_sprites as SpriteCollection)[spriteName];
+
+const G_model_getSpriteSize = () => 16;

--- a/src/model/unit.ts
+++ b/src/model/unit.ts
@@ -4,6 +4,8 @@ G_model_createActor
 G_model_actorSetFacing
 G_FACING_LEFT
 G_FACING_RIGHT
+G_model_actorSetPosition
+G_model_battleGetScreenPosition
 */
 
 interface Stats {
@@ -21,6 +23,8 @@ interface Unit {
   actor: Actor;
   bS: Stats;
   cS: Stats;
+  i: number; // vertical index of unit
+  allegiance: Allegiance;
 }
 
 const model_createStats = (
@@ -40,6 +44,7 @@ const G_model_createUnit = (
   def: number,
   mag: number,
   spd: number,
+  i: number,
   allegiance: Allegiance,
   actor?: Actor
 ): Unit => {
@@ -47,12 +52,16 @@ const G_model_createUnit = (
   allegiance
     ? G_model_actorSetFacing(actor, G_FACING_LEFT)
     : G_model_actorSetFacing(actor, G_FACING_RIGHT);
-  return {
+  const unit = {
     name,
     bS: model_createStats(hp, dmg, def, mag, spd),
     cS: model_createStats(hp, dmg, def, mag, spd),
     actor,
+    i,
+    allegiance,
   };
+  G_model_unitResetPosition(unit);
+  return unit;
 };
 
 const G_model_statsModifyHp = (
@@ -69,4 +78,22 @@ const G_model_statsModifyHp = (
     nextHp = 0;
   }
   currentStats.hp = nextHp;
+};
+
+const G_model_unitMoveForward = (unit: Unit) => {
+  const { allegiance } = unit;
+  const [x, y] = G_model_battleGetScreenPosition(unit.i, allegiance);
+  G_model_actorSetPosition(unit.actor, x + (allegiance ? -50 : 50), y);
+};
+
+const G_model_unitResetPosition = (unit: Unit) => {
+  const [x, y] = G_model_battleGetScreenPosition(unit.i, unit.allegiance);
+  G_model_actorSetPosition(unit.actor, x, y);
+};
+
+const G_model_unitLives = (unit: Unit): boolean => {
+  if (unit.cS.hp > 0) {
+    return true;
+  }
+  return false;
 };

--- a/src/model/unit.ts
+++ b/src/model/unit.ts
@@ -1,6 +1,9 @@
 /*
 global
 G_model_createActor
+G_model_actorSetFacing
+G_FACING_LEFT
+G_FACING_RIGHT
 */
 
 interface Stats {
@@ -37,9 +40,13 @@ const G_model_createUnit = (
   def: number,
   mag: number,
   spd: number,
+  allegiance: Allegiance,
   actor?: Actor
 ): Unit => {
   actor = actor || G_model_createActor(0);
+  allegiance
+    ? G_model_actorSetFacing(actor, G_FACING_LEFT)
+    : G_model_actorSetFacing(actor, G_FACING_RIGHT);
   return {
     name,
     bS: model_createStats(hp, dmg, def, mag, spd),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,3 +95,9 @@ const G_utils_windowGetHeight = () => {
 const G_utils_windowGetWidth = () => {
   return window.innerWidth;
 };
+
+const G_utils_waitMs = async (ms: number) => {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+};

--- a/src/view/draw.ts
+++ b/src/view/draw.ts
@@ -12,8 +12,11 @@ G_model_actorGetCurrentSprite
 G_model_actorSetFacing
 G_model_actorSetPosition
 G_model_getBattleInputEnabled
+G_model_battleGetScreenPosition
 G_FACING_RIGHT
 G_FACING_LEFT
+G_ALLEGIANCE_ALLY
+G_ALLEGIANCE_ENEMY
 BATTLE_MENU
 */
 
@@ -34,19 +37,6 @@ const DEFAULT_TEXT_PARAMS = {
 };
 
 // for(let i = 70; i <= 160; i+=30)
-const playerPos = [
-  [40, 70],
-  [40, 100],
-  [40, 130],
-  [40, 160],
-];
-
-const enemyPos = [
-  [200, 70],
-  [200, 100],
-  [200, 130],
-  [200, 160],
-];
 
 const gradientCache = {};
 
@@ -171,13 +161,13 @@ const G_view_drawBattle = (battle: Battle) => {
   const actionMenu = actionMenuStack[0];
   for (let i = 0; i < allies.length; i++) {
     G_model_actorSetFacing(allies[i].actor, G_FACING_RIGHT);
-    G_model_actorSetPosition(allies[i].actor, playerPos[i][0], playerPos[i][1]);
+    const [x, y] = G_model_battleGetScreenPosition(i, G_ALLEGIANCE_ALLY);
+    G_model_actorSetPosition(allies[i].actor, x, y);
     G_view_drawActor(allies[i].actor, 2);
-
     G_view_drawText(
       `${allies[i].name}: ${allies[i].cS.hp}/${allies[i].bS.hp}`,
-      playerPos[i][0] * 2 + 5,
-      playerPos[i][1] * 2 - 5,
+      x * 2 + 5,
+      y * 2 - 5,
       {
         align: 'center',
       }
@@ -186,16 +176,15 @@ const G_view_drawBattle = (battle: Battle) => {
 
   for (let i = 0; i < enemies.length; i++) {
     G_model_actorSetFacing(enemies[i].actor, G_FACING_LEFT);
-    G_model_actorSetPosition(enemies[i].actor, enemyPos[i][0], enemyPos[i][1]);
-
+    const [x, y] = G_model_battleGetScreenPosition(i, G_ALLEGIANCE_ENEMY);
+    G_model_actorSetPosition(enemies[i].actor, x, y);
     G_view_drawActor(enemies[i].actor, 2);
-
     G_view_drawText(
       `${enemies[i].name}: ${enemies[i].cS.hp.toString()}/${enemies[
         i
       ].bS.hp.toString()}`,
-      enemyPos[i][0] * 2 + 5,
-      enemyPos[i][1] * 2 - 5,
+      x * 2 + 5,
+      y * 2 - 5,
       {
         align: 'center',
       }

--- a/src/view/draw.ts
+++ b/src/view/draw.ts
@@ -28,22 +28,22 @@ interface DrawTextParams {
 const DEFAULT_TEXT_PARAMS = {
   font: 'monospace',
   color: '#fff',
-  size: 16,
+  size: 14,
   align: 'left',
 };
 
 const playerPos = [
-  [60, 90],
-  [45, 105],
-  [30, 90],
-  [45, 75],
+  [40, 70],
+  [40, 100],
+  [40, 130],
+  [40, 160],
 ];
 
 const enemyPos = [
-  [165, 90],
-  [180, 105],
-  [195, 90],
-  [180, 75],
+  [200, 70],
+  [200, 100],
+  [200, 130],
+  [200, 160],
 ];
 
 const gradientCache = {};
@@ -153,13 +153,6 @@ const G_view_drawRoom = (room: Room, x: number, y: number, scale?: number) => {
   });
 };
 
-const G_view_drawUnitHP = (unit: Unit, x: number, y: number) => {
-  const ctx = G_model_getCtx();
-  ctx.font = '14px monospace';
-  ctx.fillStyle = 'white';
-  ctx.fillText(`${unit.cS.hp}/${unit.bS.hp}`, x * 2 + 5, y * 2 - 5);
-};
-
 const G_view_drawActor = (actor: Actor, scale?: number) => {
   scale = scale || 1;
   const { x, y } = actor;
@@ -172,16 +165,20 @@ const G_view_drawActor = (actor: Actor, scale?: number) => {
 const G_view_drawBattle = (battle: Battle) => {
   G_view_clearScreen();
   G_view_drawText(`Round: ${battle.roundIndex + 1}`, 20, 20);
-  const { allies, enemies, actionMenu } = battle;
+  const { allies, enemies, actionMenuStack } = battle;
+  const actionMenu = actionMenuStack[0];
   for (let i = 0; i < allies.length; i++) {
     G_model_actorSetFacing(allies[i].actor, G_FACING_RIGHT);
     G_model_actorSetPosition(allies[i].actor, playerPos[i][0], playerPos[i][1]);
     G_view_drawActor(allies[i].actor, 2);
 
     G_view_drawText(
-      `${allies[i].cS.hp}/${allies[i].bS.hp}`,
+      `${allies[i].name}: ${allies[i].cS.hp}/${allies[i].bS.hp}`,
       playerPos[i][0] * 2 + 5,
-      playerPos[i][1] * 2 - 5
+      playerPos[i][1] * 2 - 5,
+      {
+        align: 'center',
+      }
     );
   }
 
@@ -192,9 +189,14 @@ const G_view_drawBattle = (battle: Battle) => {
     G_view_drawActor(enemies[i].actor, 2);
 
     G_view_drawText(
-      `${enemies[i].cS.hp.toString()}/${enemies[i].bS.hp.toString()}`,
+      `${enemies[i].name}: ${enemies[i].cS.hp.toString()}/${enemies[
+        i
+      ].bS.hp.toString()}`,
       enemyPos[i][0] * 2 + 5,
-      enemyPos[i][1] * 2 - 5
+      enemyPos[i][1] * 2 - 5,
+      {
+        align: 'center',
+      }
     );
   }
 

--- a/src/view/draw.ts
+++ b/src/view/draw.ts
@@ -129,7 +129,7 @@ const G_view_drawActor = (actor: Actor, scale?: number) => {
   G_view_drawSprite(sprite, px, py, scale);
 };
 
-let model_cursorIndex: number = 1;
+let model_cursorIndex: number = 0;
 
 const G_model_setCursorIndex = (i: number) => {
   model_cursorIndex = i;

--- a/src/view/draw.ts
+++ b/src/view/draw.ts
@@ -9,10 +9,14 @@ G_model_getCtx
 G_model_getCanvas
 G_model_getSprite
 G_model_actorGetCurrentSprite
+G_model_actorGetPosition
 G_model_actorSetFacing
 G_model_actorSetPosition
-G_model_getBattleInputEnabled
+G_model_battleGetCurrentRound
 G_model_battleGetScreenPosition
+G_model_getBattleInputEnabled
+G_model_roundGetActingUnit
+G_view_drawBattleText
 G_FACING_RIGHT
 G_FACING_LEFT
 G_ALLEGIANCE_ALLY
@@ -157,10 +161,15 @@ const G_view_drawActor = (actor: Actor, scale?: number) => {
 const G_view_drawBattle = (battle: Battle) => {
   G_view_clearScreen();
   G_view_drawText(`Round: ${battle.roundIndex + 1}`, 10, 40);
+  const actingUnit = G_model_roundGetActingUnit(
+    G_model_battleGetCurrentRound(battle)
+  );
+  G_view_drawText(`Turn: ${actingUnit?.name}`, 10, 60);
   const { allies, enemies, actionMenuStack } = battle;
   const actionMenu = actionMenuStack[0];
   for (let i = 0; i < allies.length; i++) {
-    const [x, y] = G_model_battleGetScreenPosition(i, G_ALLEGIANCE_ALLY);
+    const [x, y] = G_model_actorGetPosition(allies[i].actor);
+    // const [x, y] = G_model_battleGetScreenPosition(i, G_ALLEGIANCE_ALLY);
     G_model_actorSetPosition(allies[i].actor, x, y);
     G_view_drawActor(allies[i].actor, 2);
     G_view_drawText(
@@ -174,8 +183,9 @@ const G_view_drawBattle = (battle: Battle) => {
   }
 
   for (let i = 0; i < enemies.length; i++) {
-    const [x, y] = G_model_battleGetScreenPosition(i, G_ALLEGIANCE_ENEMY);
-    G_model_actorSetPosition(enemies[i].actor, x, y);
+    // const [x, y] = G_model_battleGetScreenPosition(i, G_ALLEGIANCE_ENEMY);
+    const [x, y] = G_model_actorGetPosition(enemies[i].actor);
+    // G_model_actorSetPosition(enemies[i].actor, x, y);
     G_view_drawActor(enemies[i].actor, 2);
     G_view_drawText(
       `${enemies[i].name}: ${enemies[i].cS.hp.toString()}/${enemies[
@@ -191,5 +201,8 @@ const G_view_drawBattle = (battle: Battle) => {
 
   if (G_model_getBattleInputEnabled()) {
     G_view_drawMenu(actionMenu);
+  }
+  if (battle.text) {
+    G_view_drawBattleText(battle.text);
   }
 };

--- a/src/view/draw.ts
+++ b/src/view/draw.ts
@@ -33,6 +33,7 @@ const DEFAULT_TEXT_PARAMS = {
   align: 'left',
 };
 
+// for(let i = 70; i <= 160; i+=30)
 const playerPos = [
   [40, 70],
   [40, 100],

--- a/src/view/draw.ts
+++ b/src/view/draw.ts
@@ -156,11 +156,10 @@ const G_view_drawActor = (actor: Actor, scale?: number) => {
 
 const G_view_drawBattle = (battle: Battle) => {
   G_view_clearScreen();
-  G_view_drawText(`Round: ${battle.roundIndex + 1}`, 20, 20);
+  G_view_drawText(`Round: ${battle.roundIndex + 1}`, 10, 40);
   const { allies, enemies, actionMenuStack } = battle;
   const actionMenu = actionMenuStack[0];
   for (let i = 0; i < allies.length; i++) {
-    G_model_actorSetFacing(allies[i].actor, G_FACING_RIGHT);
     const [x, y] = G_model_battleGetScreenPosition(i, G_ALLEGIANCE_ALLY);
     G_model_actorSetPosition(allies[i].actor, x, y);
     G_view_drawActor(allies[i].actor, 2);
@@ -175,7 +174,6 @@ const G_view_drawBattle = (battle: Battle) => {
   }
 
   for (let i = 0; i < enemies.length; i++) {
-    G_model_actorSetFacing(enemies[i].actor, G_FACING_LEFT);
     const [x, y] = G_model_battleGetScreenPosition(i, G_ALLEGIANCE_ENEMY);
     G_model_actorSetPosition(enemies[i].actor, x, y);
     G_view_drawActor(enemies[i].actor, 2);

--- a/src/view/ui.ts
+++ b/src/view/ui.ts
@@ -7,15 +7,15 @@ G_BLACK
 G_WHITE
 */
 
-const CURSOR_WIDTH = 16;
-const CURSOR_HEIGHT = 16;
+const G_CURSOR_WIDTH = 16;
+const G_CURSOR_HEIGHT = 16;
 
 const G_view_drawMenuCursor = (x: number, y: number) => {
   const ctx = G_model_getCtx();
-  const cursorHeight = CURSOR_HEIGHT;
-  const cursorWidth = CURSOR_WIDTH;
+  const cursorHeight = G_CURSOR_HEIGHT;
+  const cursorWidth = G_CURSOR_WIDTH;
   ctx.save();
-  ctx.translate(x - CURSOR_WIDTH / 2, y - CURSOR_HEIGHT / 2);
+  ctx.translate(x - G_CURSOR_WIDTH / 2, y - G_CURSOR_HEIGHT / 2);
   ctx.beginPath();
   ctx.moveTo(0, 0);
   ctx.lineTo(0, cursorHeight);
@@ -38,5 +38,5 @@ const G_view_drawMenu = (menu: Menu) => {
       align: 'center',
     });
   });
-  G_view_drawMenuCursor(x - CURSOR_WIDTH, y + i * lh + lh / 2);
+  G_view_drawMenuCursor(x - G_CURSOR_WIDTH, y + i * lh + lh / 2);
 };

--- a/src/view/ui.ts
+++ b/src/view/ui.ts
@@ -1,6 +1,7 @@
 /*
 global
 G_model_getCtx
+G_model_getScreenSize
 G_view_drawText
 G_view_drawRect
 G_BLACK
@@ -39,4 +40,17 @@ const G_view_drawMenu = (menu: Menu) => {
     });
   });
   G_view_drawMenuCursor(x - G_CURSOR_WIDTH, y + i * lh + lh / 2);
+};
+
+const G_view_drawBattleText = (text: string) => {
+  const x = 0;
+  const y = 0;
+  const w = G_model_getScreenSize();
+  const h = 30;
+
+  G_view_drawRect(x, y, w, h, G_BLACK);
+
+  G_view_drawText(text, G_model_getScreenSize() / 2, 16, {
+    align: 'center',
+  });
 };


### PR DESCRIPTION
* On death, units will now be removed from the turn-order and face upwards
* Adds a "flipped-&-rotated-90" set of sprites to the sprite map.
* Adds new facing directions: "up right" and "up left", depending on unit orientation.

![image](https://user-images.githubusercontent.com/42557448/90557532-dc246b00-e157-11ea-801f-6ae769b06a43.png)

![image](https://user-images.githubusercontent.com/42557448/90557567-eb0b1d80-e157-11ea-92f7-07b211251c63.png)

